### PR TITLE
Fix README phrasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ Used to extract key values ​​in FTB quest to facilitate localization transla
 
 Drag the folder onto `extract_quest.py` to extract the key values
 
-Output a folder name `out_chapters`, containing the extracted data and the file `outdict.json` that stores the key value
+Outputs to a folder named `out_chapters`, containing the extracted data and the file `outdict.json`.
 
 Drag the folder containing the localized `outdict.json` onto `refill_quest.py` to refill the key values


### PR DESCRIPTION
## Summary
- tweak wording about out_chapters output directory

## Testing
- `python -m py_compile extract_quest.py refill_quest.py`

------
https://chatgpt.com/codex/tasks/task_e_684a3dc39cb08332b0a9cc4b9fa2801d