### PR TITLE
Add basic unit tests for scripts

### DIFF
--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,25 @@
+import unittest
+
+from extract_quest import extract_text, exctract_cache
+from refill_quest import refill_text
+
+
+class TestExtractText(unittest.TestCase):
+    def test_extract_text_updates_cache_and_returns_tag(self):
+        exctract_cache.clear()
+        result = extract_text("Hello", "chapter.title.1")
+        self.assertEqual(result, "{chapter.title.1}")
+        self.assertIn("chapter.title.1", exctract_cache)
+        self.assertEqual(exctract_cache["chapter.title.1"], "Hello")
+
+
+class TestRefillText(unittest.TestCase):
+    def test_refill_text_replaces_tags(self):
+        ctx = 'title: "{chapter.title.1}"'
+        dicti = {"chapter.title.1": "Hello"}
+        filled = refill_text(ctx, dicti)
+        self.assertEqual(filled, 'title: "Hello"')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unit tests for extract_text and refill_text

## Testing
- `python -m unittest tests.test_scripts -v`

------
https://chatgpt.com/codex/tasks/task_e_684a3dca2a2083329471f0c48ad14450